### PR TITLE
Added an entropy source using hash_map::RandomState.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,7 @@ jobs:
         run: cargo build --verbose --no-default-features
       - name: Run tests with no-default-features
         run: cargo test --verbose --no-default-features
-      - name: Build with use-devrandom
-        run: cargo build --verbose --features use-devrandom
-      - name: Run tests with use-devrandom
-        run: cargo test --verbose --features use-devrandom
+      - name: Build with use-getrandom
+        run: cargo build --verbose --features use-getrandom
+      - name: Run tests with use-getrandom
+        run: cargo test --verbose --features use-getrandom

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,3 +45,7 @@ jobs:
         run: cargo build --verbose --no-default-features
       - name: Run tests with no-default-features
         run: cargo test --verbose --no-default-features
+      - name: Build with use-devrandom
+        run: cargo build --verbose --features use-devrandom
+      - name: Run tests with use-devrandom
+        run: cargo test --verbose --features use-devrandom

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ exclude = [".github/workflows/*"]
 [features]
 default = ["std"]
 std = []
+use-getrandom = ["getrandom"]
 
 [dependencies]
 [target.'cfg(not(unix))'.dependencies]
-getrandom = "0.3.2"
+getrandom = { version = "0.3.2", optional = true }

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ respectively.
 The crate is intended to be easy to audit.
 Its only dependency is [`getrandom`](https://crates.io/crates/getrandom), and that is only used on non-Linux/Unix
 platforms.
-It can also be built as no-std, in which case `getrandom` is not used at all (but you´ll then have to provide the seed
+It can also be built as no-std, in which case `getrandom` is not used at all (but you'll then have to provide the seed
 yourself).
 
 Quick start

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -143,11 +143,12 @@ impl EntropySource for GetRandom {
 #[derive(Default)]
 pub struct HashMapEntropy;
 
+#[cfg(feature = "std")]
 impl HashMapEntropy {
     /// Creates a new `HashMapEntropy` entropy source
     #[must_use]
     pub fn new() -> Self {
-        Self
+        Self {}
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ pub use entropy::DevUrandom;
 pub use entropy::EntropySource;
 #[cfg(all(not(unix), feature = "std"))]
 pub use entropy::GetRandom;
+#[cfg(feature = "std")]
+pub use entropy::HashMapEntropy;
 pub use entropy::SplitMix;
 pub use rng::Rng;
 #[cfg(feature = "std")]


### PR DESCRIPTION
 This is now the default on non-Unix platforms, unless the new use-getrandom feature flag is specified, in which case GetRandom is used instead.