### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1](https://github.com/hpenne/smallrand/compare/v0.2.0...v0.2.1) - 2025-05-16
+
+### Other
+
+- Hash map entropy ([#30](https://github.com/hpenne/smallrand/pull/30))
+
 ## [0.2.0](https://github.com/hpenne/smallrand/compare/v0.1.0...v0.2.0) - 2025-05-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "smallrand"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallrand"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT-0"


### PR DESCRIPTION



## 🤖 New release

* `smallrand`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/hpenne/smallrand/compare/v0.2.0...v0.2.1) - 2025-05-16

### Other

- Hash map entropy ([#30](https://github.com/hpenne/smallrand/pull/30))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).