### PR TITLE
Fixed the construction of the hasher in nonce_u64…

### DIFF
--- a/src/nonces.rs
+++ b/src/nonces.rs
@@ -5,9 +5,9 @@
 use core::ops::BitXor;
 use core::sync::atomic::{AtomicU64, Ordering};
 #[cfg(feature = "std")]
-use std::hash::{BuildHasher, RandomState};
+use std::collections::hash_map::RandomState;
 #[cfg(feature = "std")]
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasher, Hash, Hasher};
 
 // Define a global static atomic counter
 static NONCE_COUNTER: AtomicU64 = AtomicU64::new(0);

--- a/src/nonces.rs
+++ b/src/nonces.rs
@@ -5,7 +5,7 @@
 use core::ops::BitXor;
 use core::sync::atomic::{AtomicU64, Ordering};
 #[cfg(feature = "std")]
-use std::collections::hash_map::DefaultHasher;
+use std::hash::{BuildHasher, RandomState};
 #[cfg(feature = "std")]
 use std::hash::{Hash, Hasher};
 
@@ -24,10 +24,9 @@ pub fn nonce_u64() -> [u8; 8] {
     // Increment and get the global counter:
     let from_counter = NONCE_COUNTER.fetch_add(1, Ordering::SeqCst);
 
-    // Pass these two values through the DefaultHasher, which is in itself
-    // a source of entropy (hashing only a zero should give different output
-    // one every boot):
-    let mut hasher = DefaultHasher::new();
+    // Pass these two values through a hashed built from RandomState, which is in itself
+    // a source of entropy:
+    let mut hasher = RandomState::new().build_hasher();
     from_time.hash(&mut hasher);
     from_counter.hash(&mut hasher);
 


### PR DESCRIPTION
… to properly mix in RandomState entropy in the nonce (inspecting the source for DefaultHasher::new revealed that it seemed to use constant keys that are 0).