### PR TITLE
Replace SecureEntropy with DefaultEntropy for SmallRng::default

### DIFF
--- a/src/smallrng.rs
+++ b/src/smallrng.rs
@@ -4,7 +4,7 @@ use crate::rng::Rng;
 use crate::rng::{RangeFromRng, ValueFromRng};
 use crate::xoshiro::Xoshiro256pp;
 #[cfg(feature = "std")]
-use crate::SecureEntropy;
+use crate::DefaultEntropy;
 use crate::SplitMix;
 
 /// This is a numerically good PRNG if you need something small and fast
@@ -37,7 +37,7 @@ impl SmallRng {
     #[cfg(feature = "std")]
     #[must_use]
     pub fn new() -> Self {
-        Self(Impl::from_entropy(&mut SecureEntropy::new()))
+        Self(Impl::from_entropy(&mut DefaultEntropy::new()))
     }
 
     /// Creates a new random generator with a seed from an [EntropySource].

--- a/src/stdrng.rs
+++ b/src/stdrng.rs
@@ -229,13 +229,13 @@ impl StdRng {
     }
 }
 
-/// Creates a new random generator with a seed from a [SecureEntropy].
-/// This type of entropy source performs health tests on the system entropy source for extra security.
-/// Note that [SecureEntropy] has a small false alarm rate, which can cause intermittent fuzz test errors
-/// if a new [StdRng] instance is created for each fuzz test vector.
-/// If you need to avoid this then create your instances with `from_entropy` and pass in a [DefaultEntropy] instead.
 #[cfg(feature = "std")]
 impl Default for StdRng {
+    /// Creates a new random generator with a seed from a [SecureEntropy].
+    /// This type of entropy source performs health tests on the system entropy source for extra security.
+    /// Note that [SecureEntropy] has a small false alarm rate, which can cause intermittent fuzz test errors
+    /// if a new [StdRng] instance is created for each fuzz test vector.
+    /// If you need to avoid this then create your instances with `from_entropy` and pass in a [DefaultEntropy] instead.
     fn default() -> Self {
         Self::new()
     }

--- a/src/stdrng.rs
+++ b/src/stdrng.rs
@@ -41,6 +41,9 @@ impl Rng for StdRng {
 impl StdRng {
     /// Creates a new random generator with a seed from a [SecureEntropy].
     /// This type of entropy source performs health tests on the system entropy source for extra security.
+    /// Note that [SecureEntropy] has a small false alarm rate, which can cause intermittent fuzz test errors
+    /// if a new [StdRng] instance is created for each fuzz test vector.
+    /// If you need to avoid this then create your instances with `from_entropy` and pass in a [DefaultEntropy] instead.
     ///
     /// returns: `StdRng`
     #[cfg(feature = "std")]
@@ -226,6 +229,11 @@ impl StdRng {
     }
 }
 
+/// Creates a new random generator with a seed from a [SecureEntropy].
+/// This type of entropy source performs health tests on the system entropy source for extra security.
+/// Note that [SecureEntropy] has a small false alarm rate, which can cause intermittent fuzz test errors
+/// if a new [StdRng] instance is created for each fuzz test vector.
+/// If you need to avoid this then create your instances with `from_entropy` and pass in a [DefaultEntropy] instead.
 #[cfg(feature = "std")]
 impl Default for StdRng {
     fn default() -> Self {


### PR DESCRIPTION
Replaced SecureEntropy with DefaultEntropy for SmallRng::default.
Fixes #35.